### PR TITLE
Use a unique IV for each file

### DIFF
--- a/decrypt/main.go
+++ b/decrypt/main.go
@@ -53,7 +53,12 @@ func decryptFile(key []byte, file string) {
 		panic(err)
 	}
 
+	// Read the IV from the file first
 	var iv [aes.BlockSize]byte
+	_, err = inFile.Read(iv[:])
+	if err != nil {
+		panic(err)
+	}
 	stream := cipher.NewOFB(block, iv[:])
 
 	reader := &cipher.StreamReader{S: stream, R: inFile}

--- a/encrypt/main.go
+++ b/encrypt/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -104,9 +105,15 @@ func newBatchWriter(key []byte, batch int) *cipher.StreamWriter {
 	}
 
 	var iv [aes.BlockSize]byte
+	rand.Read(iv[:])
 	stream := cipher.NewOFB(block, iv[:])
 
 	outFile, err := os.OpenFile(fmt.Sprintf("output/batch%d.csv.bin", batch), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = outFile.Write(iv[:])
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Happened to notice this while looking through the projects. OFB encryption is not safe without a unique nonce/IV per encryption. Effectively the same key stream is generated for each file resulting in a "two time pad" (or n-time pad in this case), which allows the original plaintext to be recovered by statistical analysis after XORing the files together.